### PR TITLE
Add OTA-1C0000 variant.

### DIFF
--- a/variants/esp32-ota-1c0000/README.md
+++ b/variants/esp32-ota-1c0000/README.md
@@ -1,0 +1,7 @@
+# ESP32-OTA-1C0000
+
+A variant of the ESP32 envelope that sets the size of the OTA
+partitions to 0x1C0000 (1835008) bytes.
+
+As a consequence the size of the programs partition is set to
+0x60000 (393216) bytes.

--- a/variants/esp32-ota-1c0000/partitions.csv
+++ b/variants/esp32-ota-1c0000/partitions.csv
@@ -1,0 +1,27 @@
+# Copyright (C) 2021 Toitware ApS.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; version
+# 2.1 only.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# The license can be found in the file `LICENSE` in the top level
+# directory of this repository.
+
+# Partition Table for Toit.
+
+# Name,   Type, SubType,  Offset,    Size
+# bootloader,,  ,         0x001000,  0x007000
+# partitions,,  ,         0x008000,  0x000c00
+secure,   0x42, 0x00,     0x009000,  0x004000,
+otadata,  data, ota,      0x00d000,  0x002000,
+phy_init, data, phy,      0x00f000,  0x001000,
+ota_0,    app,  ota_0,    0x010000,  0x1c0000,
+ota_1,    app,  ota_1,    0x1d0000,  0x1c0000,
+nvs,      data, nvs,      0x390000,  0x010000,
+programs, 0x40, 0x00,     0x3A0000,  0x060000, encrypted


### PR DESCRIPTION
This variant sets the size of the OTA partitions to 0x1C0000 bytes.