### PR TITLE
Add more variants for bigger OTA partition sizes.

### DIFF
--- a/variants/esp32-ota-1d0000/README.md
+++ b/variants/esp32-ota-1d0000/README.md
@@ -1,0 +1,7 @@
+# ESP32-OTA-1D0000
+
+A variant of the ESP32 envelope that sets the size of the OTA
+partitions to 0x1D0000 (1900544) bytes.
+
+As a consequence the size of the programs partition is set to
+0x40000 (262144) bytes.

--- a/variants/esp32-ota-1d0000/partitions.csv
+++ b/variants/esp32-ota-1d0000/partitions.csv
@@ -1,0 +1,17 @@
+# Copyright (C) 2023 Toitware ApS.
+#
+# Use of this source code is governed by a BSD0-style license that can be
+# found in the LICENSE_BSD0 file.
+
+# Partition Table for Toit.
+
+# Name,   Type, SubType,  Offset,    Size
+# bootloader,,  ,         0x001000,  0x007000
+# partitions,,  ,         0x008000,  0x000c00
+secure,   0x42, 0x00,     0x009000,  0x004000,
+otadata,  data, ota,      0x00d000,  0x002000,
+phy_init, data, phy,      0x00f000,  0x001000,
+ota_0,    app,  ota_0,    0x010000,  0x1d0000,
+ota_1,    app,  ota_1,    0x1e0000,  0x1d0000,
+nvs,      data, nvs,      0x3B0000,  0x010000,
+programs, 0x40, 0x00,     0x3C0000,  0x040000, encrypted

--- a/variants/esp32s3-ota-1c0000/README.md
+++ b/variants/esp32s3-ota-1c0000/README.md
@@ -1,0 +1,7 @@
+# ESP32S3-OTA-1C0000
+
+A variant of the ESP32S3 envelope that sets the size of the OTA
+partitions to 0x1C0000 (1835008) bytes.
+
+As a consequence the size of the programs partition is set to
+0x60000 (393216) bytes.

--- a/variants/esp32s3-ota-1c0000/partitions.csv
+++ b/variants/esp32s3-ota-1c0000/partitions.csv
@@ -1,0 +1,17 @@
+# Copyright (C) 2023 Toitware ApS.
+#
+# Use of this source code is governed by a BSD0-style license that can be
+# found in the LICENSE_BSD0 file.
+
+# Partition Table for Toit.
+
+# Name,   Type, SubType,  Offset,    Size
+# bootloader,,  ,         0x001000,  0x007000
+# partitions,,  ,         0x008000,  0x000c00
+secure,   0x42, 0x00,     0x009000,  0x004000,
+otadata,  data, ota,      0x00d000,  0x002000,
+phy_init, data, phy,      0x00f000,  0x001000,
+ota_0,    app,  ota_0,    0x010000,  0x1c0000,
+ota_1,    app,  ota_1,    0x1d0000,  0x1c0000,
+nvs,      data, nvs,      0x390000,  0x010000,
+programs, 0x40, 0x00,     0x3A0000,  0x060000, encrypted

--- a/variants/esp32s3-ota-1d0000/README.md
+++ b/variants/esp32s3-ota-1d0000/README.md
@@ -1,0 +1,7 @@
+# ESP32S3-OTA-1D0000
+
+A variant of the ESP32S3 envelope that sets the size of the OTA
+partitions to 0x1D0000 (1900544) bytes.
+
+As a consequence the size of the programs partition is set to
+0x40000 (262144) bytes.

--- a/variants/esp32s3-ota-1d0000/partitions.csv
+++ b/variants/esp32s3-ota-1d0000/partitions.csv
@@ -1,0 +1,17 @@
+# Copyright (C) 2023 Toitware ApS.
+#
+# Use of this source code is governed by a BSD0-style license that can be
+# found in the LICENSE_BSD0 file.
+
+# Partition Table for Toit.
+
+# Name,   Type, SubType,  Offset,    Size
+# bootloader,,  ,         0x001000,  0x007000
+# partitions,,  ,         0x008000,  0x000c00
+secure,   0x42, 0x00,     0x009000,  0x004000,
+otadata,  data, ota,      0x00d000,  0x002000,
+phy_init, data, phy,      0x00f000,  0x001000,
+ota_0,    app,  ota_0,    0x010000,  0x1d0000,
+ota_1,    app,  ota_1,    0x1e0000,  0x1d0000,
+nvs,      data, nvs,      0x3B0000,  0x010000,
+programs, 0x40, 0x00,     0x3C0000,  0x040000, encrypted


### PR DESCRIPTION
For now only ESP32 and ESP32S3.