### PR TITLE
Note that any envelope works with the big partition tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@ directory for more variants.
 See the [partitions/esp32/README.md](partitions/esp32/README.md) for
 a list of the most commonly used partition tables. You can also browse
 the `partitions/esp32` directory for more partition tables.
+
+Since SDK v2.0.0-alpha.195 the flash size is derived from the partition
+table during flashing, so any envelope can be combined with any partition
+table. There is no longer a need for envelopes built for a specific flash
+size, such as the dedicated 16MB envelopes.

--- a/partitions/esp32/README.md
+++ b/partitions/esp32/README.md
@@ -5,6 +5,13 @@ This directory contains partition tables for ESP32 devices and their variants.
 During flashing, users can override the default partition table that comes
 with the envelope that they are flashing.
 
+> **Since SDK v2.0.0-alpha.195** the flashing tools derive the flash size from
+> the partition table itself, so any envelope can be combined with any of these
+> tables. You no longer need an envelope that was built for a specific flash
+> size; in particular, the dedicated 16MB envelopes are no longer necessary. For
+> example, a standard (4MB) envelope can be flashed together with a 16MB
+> partition table, and the device will use the full flash.
+
 Here is a list of the most commonly used partition tables:
 
 ## OTA-1C0000


### PR DESCRIPTION
Starting with SDK v2.0.0-alpha.195 the flashing tools derive the flash size from the partition table, so an envelope no longer has to be built for a specific flash size. The dedicated 16MB envelopes are no longer necessary.